### PR TITLE
Fix runtime errors with DTOs in auction

### DIFF
--- a/examples/auction/pom.xml
+++ b/examples/auction/pom.xml
@@ -17,7 +17,6 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <org.mapstruct.version>1.3.0.Beta1</org.mapstruct.version>
         <org.projectlombok.version>1.18.0</org.projectlombok.version>
     </properties>
 
@@ -155,18 +154,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct-jdk8</artifactId>
-            <version>${org.mapstruct.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct-processor</artifactId>
-            <version>${org.mapstruct.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
     </dependencies>
 
     <build>
@@ -224,11 +211,6 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                     <annotationProcessorPaths>
-                        <path>
-                            <groupId>org.mapstruct</groupId>
-                            <artifactId>mapstruct-processor</artifactId>
-                            <version>${org.mapstruct.version}</version>
-                        </path>
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>

--- a/examples/auction/src/main/java/io/simplesource/example/auction/rest/AccountProjectionController.java
+++ b/examples/auction/src/main/java/io/simplesource/example/auction/rest/AccountProjectionController.java
@@ -29,8 +29,6 @@ public final class AccountProjectionController extends BaseController {
     @Autowired
     private AccountRepository accountRepository;
     @Autowired
-    private AccountEntityToDtoMapper accountEntityToDtoMapper;
-    @Autowired
     private AccountReadService accountReadService;
 
     @RequestMapping(value = "/{accountId}/transactions", method = RequestMethod.GET)
@@ -44,10 +42,6 @@ public final class AccountProjectionController extends BaseController {
     public ResponseEntity accountDetails(@NotNull @PathVariable UUID accountId) {
         Optional<AccountView> accountDetails = accountRepository.findByAccountId(accountId.toString());
 
-        return accountDetails.map(this::toAccountDto).map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
-    }
-
-    private AccountDetailsDto toAccountDto(AccountView entity) {
-        return accountEntityToDtoMapper.toDto(entity);
+        return accountDetails.map(AccountEntityToDtoMapper::toDto).map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
     }
 }

--- a/examples/auction/src/main/java/io/simplesource/example/auction/rest/dto/AccountDto.java
+++ b/examples/auction/src/main/java/io/simplesource/example/auction/rest/dto/AccountDto.java
@@ -1,12 +1,16 @@
 package io.simplesource.example.auction.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.math.BigDecimal;
 
 public final class AccountDto {
     private final String userName;
     private final BigDecimal funds;
 
-    public AccountDto(String userName, BigDecimal funds) {
+    @JsonCreator
+    public AccountDto(@JsonProperty("userName") String userName, @JsonProperty("funds") BigDecimal funds) {
         this.userName = userName;
         this.funds = funds;
     }

--- a/examples/auction/src/main/java/io/simplesource/example/auction/rest/dto/AddAccountFundsDto.java
+++ b/examples/auction/src/main/java/io/simplesource/example/auction/rest/dto/AddAccountFundsDto.java
@@ -1,5 +1,8 @@
 package io.simplesource.example.auction.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import javax.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
@@ -7,7 +10,8 @@ public final class AddAccountFundsDto {
     @NotNull
     private final BigDecimal funds;
 
-    public AddAccountFundsDto(@NotNull BigDecimal funds) {
+    @JsonCreator
+    public AddAccountFundsDto(@JsonProperty("funds") @NotNull BigDecimal funds) {
         this.funds = funds;
     }
 

--- a/examples/auction/src/main/java/io/simplesource/example/auction/rest/dto/ConfirmReservationDto.java
+++ b/examples/auction/src/main/java/io/simplesource/example/auction/rest/dto/ConfirmReservationDto.java
@@ -1,5 +1,8 @@
 package io.simplesource.example.auction.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import javax.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
@@ -7,7 +10,8 @@ public final class ConfirmReservationDto {
     @NotNull
     private final BigDecimal amount;
 
-    public ConfirmReservationDto(@NotNull BigDecimal amount) {
+    @JsonCreator
+    public ConfirmReservationDto(@JsonProperty("amount") @NotNull BigDecimal amount) {
         this.amount = amount;
     }
 

--- a/examples/auction/src/main/java/io/simplesource/example/auction/rest/dto/CreateAccountDto.java
+++ b/examples/auction/src/main/java/io/simplesource/example/auction/rest/dto/CreateAccountDto.java
@@ -1,5 +1,8 @@
 package io.simplesource.example.auction.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
@@ -9,7 +12,8 @@ public final class CreateAccountDto {
     @NotNull
     private AccountDto accountDto;
 
-    public CreateAccountDto(@NotNull UUID accountId, @NotNull AccountDto accountDto) {
+    @JsonCreator
+    public CreateAccountDto(@JsonProperty("accountId") @NotNull UUID accountId, @JsonProperty("accountDto") @NotNull AccountDto accountDto) {
         this.accountId = accountId;
         this.accountDto = accountDto;
     }

--- a/examples/auction/src/main/java/io/simplesource/example/auction/rest/dto/ReserveFundsDto.java
+++ b/examples/auction/src/main/java/io/simplesource/example/auction/rest/dto/ReserveFundsDto.java
@@ -1,5 +1,8 @@
 package io.simplesource.example.auction.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.math.BigDecimal;
 import java.util.UUID;
 
@@ -8,7 +11,8 @@ public final class ReserveFundsDto {
     private final BigDecimal amount;
     private final String description;
 
-    public ReserveFundsDto(UUID reservationId, BigDecimal amount, String description) {
+    @JsonCreator
+    public ReserveFundsDto(@JsonProperty("reservationId") UUID reservationId, @JsonProperty("amount") BigDecimal amount, @JsonProperty("description") String description) {
         this.reservationId = reservationId;
         this.amount = amount;
         this.description = description;

--- a/examples/auction/src/main/java/io/simplesource/example/auction/rest/dto/UpdateAccountDto.java
+++ b/examples/auction/src/main/java/io/simplesource/example/auction/rest/dto/UpdateAccountDto.java
@@ -1,12 +1,16 @@
 package io.simplesource.example.auction.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import javax.validation.constraints.NotBlank;
 
 public final class UpdateAccountDto {
     @NotBlank
     private final String userName;
 
-    public UpdateAccountDto(@NotBlank String userName) {
+    @JsonCreator
+    public UpdateAccountDto(@JsonProperty("userName") @NotBlank String userName) {
         this.userName = userName;
     }
 

--- a/examples/auction/src/main/java/io/simplesource/example/auction/rest/dtomappers/AccountEntityToDtoMapper.java
+++ b/examples/auction/src/main/java/io/simplesource/example/auction/rest/dtomappers/AccountEntityToDtoMapper.java
@@ -2,8 +2,22 @@ package io.simplesource.example.auction.rest.dtomappers;
 
 import io.simplesource.example.auction.account.query.views.AccountView;
 import io.simplesource.example.auction.rest.dto.AccountDetailsDto;
-import org.mapstruct.Mapper;
 
-public interface AccountEntityToDtoMapper {
-    AccountDetailsDto toDto(AccountView entity);
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class AccountEntityToDtoMapper {
+    public static AccountDetailsDto toDto(AccountView entity) {
+        return new AccountDetailsDto(
+            entity.getId(),
+            entity.getUserName(),
+            entity.getFunds(),
+            entity.getAvailableFunds(),
+            entity.getLastEventSequence(),
+            entity.getDraftReservations()
+                .stream()
+                .map(AccountTransactionDtoMapper::toDto)
+                .collect(Collectors.toList())
+        );
+    }
 }

--- a/examples/auction/src/main/java/io/simplesource/example/auction/rest/dtomappers/AccountTransactionDtoMapper.java
+++ b/examples/auction/src/main/java/io/simplesource/example/auction/rest/dtomappers/AccountTransactionDtoMapper.java
@@ -1,0 +1,15 @@
+package io.simplesource.example.auction.rest.dtomappers;
+
+import io.simplesource.example.auction.rest.dto.AccountTransactionDto;
+import io.simplesource.example.auction.account.query.views.ReservationView;
+
+public final class AccountTransactionDtoMapper {
+    public static AccountTransactionDto toDto(ReservationView reservation) {
+        return new AccountTransactionDto(
+            reservation.getReservationId(),
+            reservation.getDescription(),
+            reservation.getAmount(),
+            reservation.getStatus()
+        );
+    }
+}


### PR DESCRIPTION
Fixes two runtime reflection errors related to changing DTOs to be
immutable:

1. NoSuchBeanException for AccountEntityToDtoMapper; the MapStruct
   annotation was removed, so no implementation for
   AccountEntityToDtoMapper existed. MapStruct expects to use a default
   constructor to create the target class and then mutate the fields in
   place, but this isn't an option with the current DTO design. Used the
   hand-written implementation instead.
2. HttpMessageConversionException for any HTTP end-point that accepts a
   JSON request body. In the absence of a default constructor Jackson
   was unable to create the target class when deserialising request
   bodies. Extra annotations are required for Jackson to use another
   constructor.